### PR TITLE
Patch Desktop Safari regexp to exclude Chrome and etc.

### DIFF
--- a/src/useragentRegexp/useragentRegexp.spec.ts
+++ b/src/useragentRegexp/useragentRegexp.spec.ts
@@ -49,6 +49,7 @@ function *getUserAgents() {
 			}
 
 			userAgents.add(data.userAgent);
+
 			yield {
 				versions:  versions.map(_ => `${_.family} ${_.version.join('.')}`),
 				userAgent: data.userAgent,

--- a/src/useragentRegexp/workarounds.ts
+++ b/src/useragentRegexp/workarounds.ts
@@ -56,6 +56,34 @@ const patches: IBrowserPatch[] = [
 				regExpString: patchedRegExpString
 			};
 		}
+	},
+	/**
+	 * Patch Desktop Safari regexp to exclude Chrome and etc.
+	 */
+	{
+		test(browsers) {
+			return browsers.has('safari');
+		},
+		patch(regExpInfo) {
+
+			const {
+				family,
+				regExpString
+			} = regExpInfo;
+
+			if (family !== 'safari') {
+				return regExpInfo;
+			}
+
+			const patchedRegExpString = regExpString.replace(/\.\*(Safari\\\/)/, ' $1');
+			const patchedRegExp = new RegExp(patchedRegExpString);
+
+			return {
+				...regExpInfo,
+				regExp:       patchedRegExp,
+				regExpString: patchedRegExpString
+			};
+		}
 	}
 ];
 


### PR DESCRIPTION
https://github.com/browserslist/browserslist-useragent-regexp/issues/420