### PR TITLE
Makes the machine-specific instructions more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ not dead
 
 2) Add script to `package.json`:
 
+**On Unix machines**
 ```json
 {
   "scripts": {
@@ -48,9 +49,7 @@ not dead
 }
 ```
 
-<details>
-    <summary>for Windows users</summary>
-
+**On Windows machines**
 ```json
 {
   "scripts": {
@@ -58,8 +57,6 @@ not dead
   }
 }
 ```
-
-</details>
 
 3) Run this script, to compile RegExp:
 


### PR DESCRIPTION
I missed the fact that there was a different script to use on Windows machines as that information was hidden in a spoiler block. Only found this when coming across #36 after searching through closed issues.