### PR TITLE
fix allowZeroSubversions cli option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,7 +36,7 @@ const {
 	'ignorePatch',
 	'ignoreMinor',
 	'allowHigherVersions',
-	'allowZeroVersions'
+	'allowZeroSubversions'
 ], []);
 
 if (help) {


### PR DESCRIPTION
When passing `--allowZeroSubversions` to the CLI, I was getting the following error
```
Error: Unexpected key "allowZeroSubversions".
```
Looks like it was expecting the key to be called `allowZeroVersions`.