### PR TITLE
Depend on @types/node 16 or 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "regexp"
   ],
   "dependencies": {
-    "@types/node": "^16.9.6",
+    "@types/node": "^16.9.6 || ^18.0.0",
     "argue-cli": "^1.2.0",
     "browserslist": "^4.16.3",
     "chalk": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1711,10 +1711,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*", "@types/node@^16.9.6":
-  version "16.10.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.2.tgz#5764ca9aa94470adb4e1185fe2e9f19458992b2e"
-  integrity sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==
+"@types/node@*", "@types/node@^16.9.6 || ^18.0.0":
+  version "18.7.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.18.tgz#633184f55c322e4fb08612307c274ee6d5ed3154"
+  integrity sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
This package currently depends on @types/node for node 16. Node 16 is the active LTS release, while 18 is the current (and future LTS) release.

The types seem to be compatible, widening this dependency version will allow consumers to upgrade Node versions without duplicating a @types/node dependency.

Closes https://github.com/browserslist/browserslist-useragent-regexp/pull/1399 (superseded).