### PR TITLE
feat: allow all browserslist options via JS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,12 @@ Compile browserslist query to one regex.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | browsers | `string \| string[]` | — | Manually provide a browserslist query (or an array of queries). Specifying this overrides the browserslist configuration specified in your project. |
-| env | `string` | — | When multiple browserslist [environments](https://github.com/ai/browserslist#environments) are specified, pick the config belonging to this environment. |
 | ignorePatch | `boolean` | `true` | Ignore differences in patch browser numbers. |
 | ignoreMinor | `boolean` | `false` | Ignore differences in minor browser versions. |
 | allowHigherVersions | `boolean` | `false` | For all the browsers in the browserslist query, return a match if the useragent version is equal to or higher than the one specified in browserslist. |
 | allowZeroSubversions | `boolean` | `false` | Ignore match of patch or patch and minor, if they are 0. |
+
+Any of the [`browserslist` API options](https://github.com/browserslist/browserslist#js-api) may also be provided.
 
 #### Regex info object
 

--- a/src/browsers/browserslist.ts
+++ b/src/browsers/browserslist.ts
@@ -44,13 +44,9 @@ export function parseBrowsersList(browsersList: string[]) {
 export function getBrowsersList(options: BrowserslistRequest = {}) {
   const {
     browsers,
-    env,
-    path
+    ...browserslistOptions
   } = options
-  const browsersList = browserslist(browsers, {
-    env,
-    path
-  })
+  const browsersList = browserslist(browsers, browserslistOptions)
   const parsedBrowsers = parseBrowsersList(browsersList)
 
   return parsedBrowsers

--- a/src/browsers/types.ts
+++ b/src/browsers/types.ts
@@ -1,3 +1,5 @@
+import type browserslist from 'browserslist'
+import type { Options } from 'browserslist'
 import type {
   Semver,
   RangedSemver
@@ -8,10 +10,8 @@ export interface Browser {
   version: Semver
 }
 
-export interface BrowserslistRequest {
-  browsers?: string | string[]
-  env?: string
-  path?: string
+export interface BrowserslistRequest extends Options {
+  browsers?: Parameters<typeof browserslist>[0]
 }
 
 export type BrowsersVersions = Map<string, Semver[]>

--- a/src/useragentRegex/useragentRegex.ts
+++ b/src/useragentRegex/useragentRegex.ts
@@ -2,8 +2,7 @@ import type { SemverCompareOptions } from '../semver/index.js'
 import { getRegexesForBrowsers } from '../useragent/index.js'
 import {
   getBrowsersList,
-  mergeBrowserVersions,
-  type BrowserslistRequest
+  mergeBrowserVersions
 } from '../browsers/index.js'
 import { applyVersionsToRegexes } from '../versions/index.js'
 import type { UserAgentRegexOptions } from './types.js'
@@ -25,23 +24,14 @@ export const defaultOptions = {
  * @returns Source regexes objects.
  */
 export function getPreUserAgentRegexes(options: UserAgentRegexOptions = {}) {
-  const regexpOptions: SemverCompareOptions = {
-    ...defaultOptions
+  const finalOptions = {
+    ...defaultOptions,
+    ...options
   }
-  const browserslistOptions: BrowserslistRequest = {}
-
-  for (const optName of Object.keys(options) as (keyof UserAgentRegexOptions)[]) {
-    if (optName in defaultOptions) {
-      regexpOptions[optName] = options[optName]
-    } else {
-      browserslistOptions[optName] = options[optName]
-    }
-  }
-
-  const browsersList = getBrowsersList(browserslistOptions)
+  const browsersList = getBrowsersList(finalOptions)
   const mergedBrowsers = mergeBrowserVersions(browsersList)
-  const sourceRegexes = getRegexesForBrowsers(mergedBrowsers, regexpOptions)
-  const versionedRegexes = applyVersionsToRegexes(sourceRegexes, regexpOptions)
+  const sourceRegexes = getRegexesForBrowsers(mergedBrowsers, finalOptions)
+  const versionedRegexes = applyVersionsToRegexes(sourceRegexes, finalOptions)
 
   return versionedRegexes
 }


### PR DESCRIPTION
Fixes #1484 by allowing the JS API to pass any non-regex option to `browserslist`.  I implemented this in a way that is both backwards compatible and doesn't require knowledge of the `browserslist` options.

This doesn't implement for the CLI as the current `env` and `path` options aren't possible there either and doing so requires listing out all the `browserslist` options.