### PR TITLE
Add test for shorter iOS user agent string

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,6 @@
 name: Tests
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/test/useragents.ts
+++ b/test/useragents.ts
@@ -160,6 +160,13 @@ export const useragents = [
     yes: ['ios_saf 15']
   },
   /**
+   * iOS iPhone App (WKWebView)
+   */
+  {
+    ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Mobile/15E148',
+    yes: ['ios_saf 15']
+  },
+  /**
    * Opera Mini
    */
   {


### PR DESCRIPTION
https://github.com/browserslist/browserslist-useragent-regexp/issues/1528

What problem are you trying to solve? (for `browserslist`)

The current iOS or ios_saf queries don't seem to recognise the embedded browser in a native iOS app using WKWebView component.

This test passes and indicates problem not here. 